### PR TITLE
Braces autocompletion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
 group 'org.cutejs'
 version '0.1'
 
-apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.grammarkit'
 
@@ -29,6 +28,34 @@ sourceSets {
         kotlin.srcDirs += ['src/main/kotlin']
         resources.srcDirs = ['src/main/resources']
     }
+}
+
+sourceCompatibility = 1.8
+
+grammarKit {
+    jflexRelease = '1.7.0'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation fileTree(dir: '/Applications/WebStorm.app/Contents/plugins/JavaScriptLanguage/lib', include: ['JavaScriptLanguage.jar', 'javascript-openapi.jar'])
+}
+
+intellij {
+    version '2018.1.1'
+}
+
+patchPluginXml {
+    changeNotes """
+      Initial release.<br>
+      Features:<br>
+      * Layered syntax highlighting
+      """
 }
 
 import org.jetbrains.grammarkit.tasks.*
@@ -60,38 +87,7 @@ task generateParser(type: GenerateParser) {
     outputs.upToDateWhen { false }
 }
 
-sourceCompatibility = 1.8
-
-grammarKit {
-    jflexRelease = '1.7.0'
-}
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-}
-
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 compileKotlin.dependsOn(generateLexer, generateParser)
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
-intellij {
-    version '2018.1.1'
-}
-
-patchPluginXml {
-    changeNotes """
-      Initial release.<br>
-      Features:<br>
-      * Layered syntax highlighting
-      """
-}

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 
 intellij {
     version '2018.1.1'
+    alternativeIdePath = '/Applications/WebStorm.app'
+    plugins = ['PsiViewer:2018.1']
 }
 
 patchPluginXml {

--- a/src/main/grammar/CuteJS.bnf
+++ b/src/main/grammar/CuteJS.bnf
@@ -20,6 +20,8 @@ private item_ ::= (
     | block_close_statement
     | T_TEMPLATE_HTML_CODE
     | T_TEMPLATE_JAVASCRIPT_CODE
+    | T_INNER_TEMPLATE_ELEMENT
+    | T_OUTER_TEMPLATE_ELEMENT
     | COMMENT
 )
 

--- a/src/main/kotlin/org/cutejs/file/CuteFileViewProvider.kt
+++ b/src/main/kotlin/org/cutejs/file/CuteFileViewProvider.kt
@@ -82,7 +82,7 @@ class CuteFileViewProvider : MultiplePsiFilesPerDocumentFileViewProvider, Templa
         private val TEMPLATE_MARKUP_DATA_TYPE = TemplateDataElementType("TEMPLATE_MARKUP", CuteLanguage.INSTANCE,
                 CuteTypes.T_TEMPLATE_HTML_CODE, CuteTypes.T_OUTER_TEMPLATE_ELEMENT)
 
-        private val TEMPLATE_INNERJS_DATA_TYPE = TemplateDataElementType("TEMPLATE_JS", CuteInnerJSLanguage.INSTANCE,
+        private val TEMPLATE_INNERJS_DATA_TYPE = CuteInnerJSElementType("TEMPLATE_JS", CuteInnerJSLanguage.INSTANCE,
                 CuteTypes.T_TEMPLATE_JAVASCRIPT_CODE, CuteTypes.T_INNER_TEMPLATE_ELEMENT)
     }
 }

--- a/src/main/kotlin/org/cutejs/file/CuteInnerJSElementType.kt
+++ b/src/main/kotlin/org/cutejs/file/CuteInnerJSElementType.kt
@@ -1,0 +1,12 @@
+package org.cutejs.file
+
+import com.intellij.psi.templateLanguages.TemplateDataElementType
+import com.intellij.lang.Language;
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.templateLanguages.TemplateLanguageFileViewProvider
+
+class CuteInnerJSElementType(debugName: String, language: Language, templateElementType: IElementType, outerElementType: IElementType) : TemplateDataElementType(debugName, language, templateElementType, outerElementType) {
+    override fun getTemplateFileLanguage(viewProvider: TemplateLanguageFileViewProvider): Language {
+        return language
+    }
+}

--- a/src/main/kotlin/org/cutejs/ide/typing/CuteBlockTypedHandler.kt
+++ b/src/main/kotlin/org/cutejs/ide/typing/CuteBlockTypedHandler.kt
@@ -28,7 +28,7 @@ class CuteBlockTypedHandler : TypedHandlerDelegate() {
         if (previousChars == delimiters.first) {
             val elementAt = file.viewProvider.findElementAt(offset, CuteLanguage.INSTANCE)
 
-            if (elementAt?.text?.contains("}}") != null) {
+            if (elementAt != null && elementAt.text.contains("}}")) {
                 return Result.CONTINUE
             }
 

--- a/src/main/kotlin/org/cutejs/ide/typing/CuteBlockTypedHandler.kt
+++ b/src/main/kotlin/org/cutejs/ide/typing/CuteBlockTypedHandler.kt
@@ -1,0 +1,40 @@
+package org.cutejs.ide.typing
+
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Pair
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+
+import org.cutejs.lang.CuteLanguage
+import org.cutejs.lang.psi.CuteFile
+
+class CuteBlockTypedHandler : TypedHandlerDelegate() {
+    override fun beforeCharTyped(c: Char, project: Project, editor: Editor, file: PsiFile, fileType: FileType): Result {
+        if (file !is CuteFile) return Result.CONTINUE
+        val offset = editor.caretModel.offset
+
+        val delimiters = Pair.create("{", "}}")
+        val openBraceLength = (delimiters.first as String).length
+
+        if (offset < openBraceLength) {
+            return Result.CONTINUE
+        }
+
+        val previousChars = editor.document.getText(TextRange(offset - openBraceLength, offset))
+
+        if (previousChars == delimiters.first) {
+            val elementAt = file.viewProvider.findElementAt(offset, CuteLanguage.INSTANCE)
+
+            if (elementAt?.text?.contains("}}") != null) {
+                return Result.CONTINUE
+            }
+
+            editor.document.insertString(offset, delimiters.second)
+        }
+
+        return Result.CONTINUE
+    }
+}

--- a/src/main/kotlin/org/cutejs/ide/typing/CuteBlockTypedHandler.kt
+++ b/src/main/kotlin/org/cutejs/ide/typing/CuteBlockTypedHandler.kt
@@ -2,20 +2,21 @@ package org.cutejs.ide.typing
 
 import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.StdFileTypes
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Pair
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
+import org.cutejs.lang.CuteFileType
 
 import org.cutejs.lang.CuteLanguage
 import org.cutejs.lang.parser.CuteParserDefinition
-import org.cutejs.lang.psi.CuteFile
 import org.cutejs.lang.psi.CuteTypes
 
 class CuteBlockTypedHandler : TypedHandlerDelegate() {
     override fun charTyped(c: Char, project: Project, editor: Editor, file: PsiFile): Result {
-        if (file !is CuteFile) return Result.CONTINUE
+        if (file.fileType !in arrayOf(CuteFileType.INSTANCE, StdFileTypes.HTML)) return Result.CONTINUE
+
         val offset = editor.caretModel.offset
 
         val blockOpenSymbols = arrayOf(' ', '@', '$', '=', '-', '%', '*', '#')
@@ -44,7 +45,6 @@ class CuteBlockTypedHandler : TypedHandlerDelegate() {
         }
 
         val previousChars = editor.document.getText(TextRange(offset - openBraceLength, offset))
-
         if (previousChars == delimiters.first) {
             val elementAt = file.viewProvider.findElementAt(offset, CuteLanguage.INSTANCE)
 

--- a/src/main/kotlin/org/cutejs/ide/typing/CuteBraceMatcher.kt
+++ b/src/main/kotlin/org/cutejs/ide/typing/CuteBraceMatcher.kt
@@ -1,0 +1,39 @@
+package org.cutejs.ide.typing
+
+import com.intellij.lang.BracePair
+import com.intellij.lang.PairedBraceMatcher
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
+
+import org.cutejs.lang.psi.CuteTypes.*
+
+class CuteBraceMatcher : PairedBraceMatcher {
+    override fun getCodeConstructStart(file: PsiFile?, openingBraceOffset: Int): Int {
+        return openingBraceOffset
+    }
+
+    override fun getPairs(): Array<BracePair> {
+        return OPEN_BRACE.types.map {
+            BracePair(it, T_CLOSE_BLOCK_MARKER, true)
+        }.toTypedArray()
+    }
+
+    override fun isPairedBracesAllowedBeforeType(lbraceType: IElementType, contextType: IElementType?): Boolean {
+        return true
+    }
+
+    companion object {
+        fun tokenSetOf(vararg tokens: IElementType) = TokenSet.create(*tokens)
+        private val OPEN_BRACE = tokenSetOf(
+                T_OPEN_BLOCK_MARKER,
+                T_OPEN_BLOCK_MARKER_ESCAPED,
+                T_OPEN_BLOCK_MARKER_EXPORT_DATA,
+                T_OPEN_BLOCK_MARKER_UNESCAPED,
+                T_OPEN_BLOCK_MARKER_INCLUDE,
+                T_OPEN_BLOCK_MARKER_INLINE,
+                T_OPEN_BLOCK_MARKER_NAMESPACE_DECLARATION,
+                T_OPEN_BLOCK_MARKER_VAR_TYPE_DECLARATION
+        )
+    }
+}

--- a/src/main/kotlin/org/cutejs/lang/CuteInnerJSLanguage.kt
+++ b/src/main/kotlin/org/cutejs/lang/CuteInnerJSLanguage.kt
@@ -1,0 +1,14 @@
+package org.cutejs.lang
+
+import com.intellij.lang.javascript.DialectOptionHolder
+import com.intellij.lang.javascript.JSLanguageDialect
+
+class CuteInnerJSLanguage protected constructor() : JSLanguageDialect("CuteInnerJS", DialectOptionHolder.OTHER) {
+    override fun getFileExtension(): String {
+        return "js"
+    }
+
+    companion object {
+        val INSTANCE = CuteInnerJSLanguage()
+    }
+}

--- a/src/main/kotlin/org/cutejs/lang/parser/CuteInnerJSParserDefinition.kt
+++ b/src/main/kotlin/org/cutejs/lang/parser/CuteInnerJSParserDefinition.kt
@@ -1,0 +1,17 @@
+package org.cutejs.lang.parser
+
+import org.cutejs.lang.CuteInnerJSLanguage
+
+import com.intellij.lang.javascript.nashorn.NashornJSParserDefinition;
+import com.intellij.lang.javascript.types.JSFileElementType;
+import com.intellij.psi.tree.IFileElementType;
+
+class CuteInnerJSParserDefinition : NashornJSParserDefinition() {
+    override fun getFileNodeType(): IFileElementType {
+        return FILE
+    }
+
+    companion object {
+        private val FILE = JSFileElementType.create(CuteInnerJSLanguage.INSTANCE)
+    }
+}

--- a/src/main/kotlin/org/cutejs/lang/parser/CuteParserDefinition.kt
+++ b/src/main/kotlin/org/cutejs/lang/parser/CuteParserDefinition.kt
@@ -13,13 +13,13 @@ import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.TokenType
 
 import org.cutejs.lang.lexer.CuteLexer
-import org.cutejs.lang.psi.CuteTypes
+import org.cutejs.lang.psi.CuteTypes.*
 import org.cutejs.lang.psi.CuteFile
 import org.cutejs.file.CuteFileElementType
 
 class CuteParserDefinition : ParserDefinition {
     private val tsWHITESPACES = TokenSet.create(TokenType.WHITE_SPACE)
-    private val tsCOMMENTS = TokenSet.create(CuteTypes.COMMENT)
+    private val tsCOMMENTS = TokenSet.create(COMMENT)
 
     override fun createParser(project: Project): PsiParser {
         return CuteParser()
@@ -50,10 +50,24 @@ class CuteParserDefinition : ParserDefinition {
     }
 
     override fun createElement(node: ASTNode): PsiElement {
-        return CuteTypes.Factory.createElement(node)
+        return Factory.createElement(node)
     }
 
     override fun getCommentTokens(): TokenSet {
         return tsCOMMENTS
+    }
+
+    companion object {
+        val OPEN_BLOCK_MARKERS = TokenSet.create(
+                BLOCK_OPEN_STATEMENT,
+                T_OPEN_BLOCK_MARKER,
+                T_OPEN_BLOCK_MARKER_ESCAPED,
+                T_OPEN_BLOCK_MARKER_EXPORT_DATA,
+                T_OPEN_BLOCK_MARKER_UNESCAPED,
+                T_OPEN_BLOCK_MARKER_INCLUDE,
+                T_OPEN_BLOCK_MARKER_INLINE,
+                T_OPEN_BLOCK_MARKER_NAMESPACE_DECLARATION,
+                T_OPEN_BLOCK_MARKER_VAR_TYPE_DECLARATION
+        )
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,10 +12,12 @@
 
     <idea-version since-build="173.0"/>
     <depends>com.intellij.modules.lang</depends>
+    <depends>JavaScript</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <fileTypeFactory implementation="org.cutejs.lang.CuteFileTypeFactory"/>
         <lang.parserDefinition language="CuteJSTemplate" implementationClass="org.cutejs.lang.parser.CuteParserDefinition"/>
+        <lang.parserDefinition language="CuteInnerJS" implementationClass="org.cutejs.lang.parser.CuteInnerJSParserDefinition"/>
         <lang.syntaxHighlighterFactory language="CuteJSTemplate" implementationClass="org.cutejs.ide.highlight.CuteHighlighterFactory"/>
         <lang.braceMatcher language="CuteJSTemplate" implementationClass="org.cutejs.ide.typing.CuteBraceMatcher"/>
         <typedHandler implementation="org.cutejs.ide.typing.CuteBlockTypedHandler"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,8 @@
         <fileTypeFactory implementation="org.cutejs.lang.CuteFileTypeFactory"/>
         <lang.parserDefinition language="CuteJSTemplate" implementationClass="org.cutejs.lang.parser.CuteParserDefinition"/>
         <lang.syntaxHighlighterFactory language="CuteJSTemplate" implementationClass="org.cutejs.ide.highlight.CuteHighlighterFactory"/>
+        <lang.braceMatcher language="CuteJSTemplate" implementationClass="org.cutejs.ide.typing.CuteBraceMatcher"/>
+        <typedHandler implementation="org.cutejs.ide.typing.CuteBlockTypedHandler"/>
         <editorHighlighterProvider filetype="CuteJSTemplate" implementationClass="org.cutejs.ide.highlight.CuteEditorHighlighterProvider"/>
         <fileType.fileViewProviderFactory filetype="CuteJSTemplate" implementationClass="org.cutejs.file.CuteFileViewProviderFactory"/>
     </extensions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,6 @@
         <lang.braceMatcher language="CuteJSTemplate" implementationClass="org.cutejs.ide.typing.CuteBraceMatcher"/>
         <typedHandler implementation="org.cutejs.ide.typing.CuteBlockTypedHandler"/>
         <editorHighlighterProvider filetype="CuteJSTemplate" implementationClass="org.cutejs.ide.highlight.CuteEditorHighlighterProvider"/>
-        <fileType.fileViewProviderFactory filetype="CuteJSTemplate" implementationClass="org.cutejs.file.CuteFileViewProviderFactory"/>
+        <lang.fileViewProviderFactory language="CuteJSTemplate" implementationClass="org.cutejs.file.CuteFileViewProviderFactory"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Implemented braces auto-complete:
1. `{{<caret>` -> `{{<caret>}}` - now when you typed *{{* any where in template contents ide will insert *}}* after caret
2. `{{<caret>}}` -> `{{@_<caret>_}}` - when typed extra-open symbol (*@*, *#*, etc.) standing inside braces ide will insert spaces around caret

Additional changes:
* fixed FileViewProvider for whole lang (now html and js code analyses working properly)
* some changes in gradle.build file (less unnecessary things) + configured for debugging plugin in local distro of webstorm